### PR TITLE
chore: Try to fix the run in Open Community Build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ ThisBuild / scalacOptions ++= Seq(
 ThisBuild / scalacOptions += (scalaVersion.value match {
   case ScalaLTS => "-Ykind-projector:underscores"
   case ScalaNext => "-Xkind-projector:underscores"
+  case _ => "-Ykind-projector:underscores"
 })
 ThisBuild / publish / skip := (scalaVersion.value != ScalaLTS)
 


### PR DESCRIPTION
The Open Community Build is used to track if any change to the compiler might cause a regression in any existing open source project. The tool is quite complex, but in reality it tries to replace the Scala version to the tested one and it fails after the recent changes. Would be ok to change this a bit?

The failure can be seen in https://github.com/VirtusLab/community-build3/actions/runs/14573442352/job/40875535350